### PR TITLE
Potential fix for code scanning alert no. 54: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/gcruz3291-lab/juice-shop-ada-1466/security/code-scanning/54](https://github.com/gcruz3291-lab/juice-shop-ada-1466/security/code-scanning/54)

To fix the code injection vulnerability, the remedy is to avoid passing user input (even truncated or partially sanitized) directly into MongoDB's `$where` clause. Instead, user input should be safely used via parameterized queries or standard field comparison operators (`$eq`, etc.) rather than JavaScript code evaluation. So, the correct fix is to replace the `$where` query with a query that explicitly matches the `orderId` field. For example, `db.ordersCollection.find({ orderId: id })`. Only if `$where` is strictly required (for more complex matching), the code must ensure robust input validation or sanitization, but that is not the case here.

All changes will be within `routes/trackOrder.ts`. Specifically:
- Replace line 18 to query MongoDB using `{ orderId: id }` instead of `$where: ...` with interpolated string.

No additional imports or library methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
