### PR TITLE
Potential fix for code scanning alert no. 53: Code injection

### DIFF
--- a/routes/showProductReviews.ts
+++ b/routes/showProductReviews.ts
@@ -28,12 +28,14 @@ global.sleep = (time: number) => {
 export function showProductReviews () {
   return (req: Request, res: Response, next: NextFunction) => {
     // Truncate id to avoid unintentional RCE
-    const id = !utils.isChallengeEnabled(challenges.noSqlCommandChallenge) ? Number(req.params.id) : utils.trunc(req.params.id, 40)
+    const challengeEnabled = utils.isChallengeEnabled(challenges.noSqlCommandChallenge)
+    // Always parse id to a number if not in challenge mode; otherwise, still expect a number for safety, only truncate string for CTF logic if needed
+    const id = challengeEnabled ? Number(utils.trunc(req.params.id, 40)) : Number(req.params.id)
 
     // Measure how long the query takes, to check if there was a nosql dos attack
     const t0 = new Date().getTime()
 
-    db.reviewsCollection.find({ $where: 'this.product == ' + id }).then((reviews: Review[]) => {
+    db.reviewsCollection.find({ product: id }).then((reviews: Review[]) => {
       const t1 = new Date().getTime()
       challengeUtils.solveIf(challenges.noSqlCommandChallenge, () => { return (t1 - t0) > 2000 })
       const user = security.authenticatedUsers.from(req)


### PR DESCRIPTION
Potential fix for [https://github.com/gcruz3291-lab/juice-shop-ada-1466/security/code-scanning/53](https://github.com/gcruz3291-lab/juice-shop-ada-1466/security/code-scanning/53)

To fix this code injection flaw without changing functionality, user-supplied input must not be directly interpolated into code executed by MongoDB's `$where` operator. The safest solution is to avoid the use of `$where` (and thus JavaScript-based queries) altogether. Instead, use MongoDB's built-in query selectors (e.g., `{ product: id }`). This requires that the input be parsed and/or validated to match the type in the database (such as ensuring `id` is a number if products are indexed numerically), or left as a string if appropriate. The query should then use `{ product: id }` instead of `{ $where: ... }`. If it's necessary to retain challenge logic (for CTF reasons), the code can fall back to the `$where` query in the challenge mode, but it still should properly escape or restrict types.

**Required changes:**
- Update `routes/showProductReviews.ts`, especially the query on line 36.
- Replace the call to `$where` with a safe property query using the parsed `id`, unless in challenge mode (if challenge-specific code is required, extra escaping/parsing should be added).
- Ensure `id` is parsed to the correct type (`Number` or `String`) as needed.
- No external libraries are strictly necessary.
- No changes are required in `lib/utils.ts` beyond what is strictly needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
